### PR TITLE
Change `: ToString` to `: Into<String>`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,4 @@
+# 0.2.0
+
+## Changed
+ - Several `T: ToString` bounds were changed to `T: Into<String>`.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ariadne"
-version = "0.1.5"
+version = "0.2.0"
 description = "A fancy diagnostics & reporting crate"
 authors = ["Joshua Barretto <joshua.s.barretto@gmail.com>"]
 license = "MIT"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -87,8 +87,8 @@ impl<S> Label<S> {
     }
 
     /// Give this label a message.
-    pub fn with_message<M: ToString>(mut self, msg: M) -> Self {
-        self.msg = Some(msg.to_string());
+    pub fn with_message<M: Into<String>>(mut self, msg: M) -> Self {
+        self.msg = Some(msg.into());
         self
     }
 
@@ -215,34 +215,34 @@ impl<S: Span> ReportBuilder<S> {
     }
 
     /// Set the message of this report.
-    pub fn set_message<M: ToString>(&mut self, msg: M) {
-        self.msg = Some(msg.to_string());
+    pub fn set_message<M: Into<String>>(&mut self, msg: M) {
+        self.msg = Some(msg.into());
     }
 
     /// Add a message to this report.
-    pub fn with_message<M: ToString>(mut self, msg: M) -> Self {
-        self.msg = Some(msg.to_string());
+    pub fn with_message<M: Into<String>>(mut self, msg: M) -> Self {
+        self.msg = Some(msg.into());
         self
     }
 
     /// Set the note of this report.
-    pub fn set_note<N: ToString>(&mut self, note: N) {
-        self.note = Some(note.to_string());
+    pub fn set_note<N: Into<String>>(&mut self, note: N) {
+        self.note = Some(note.into());
     }
 
     /// Set the note of this report.
-    pub fn with_note<N: ToString>(mut self, note: N) -> Self {
+    pub fn with_note<N: Into<String>>(mut self, note: N) -> Self {
         self.set_note(note);
         self
     }
 
     /// Set the help message of this report.
-    pub fn set_help<N: ToString>(&mut self, note: N) {
-        self.help = Some(note.to_string());
+    pub fn set_help<N: Into<String>>(&mut self, note: N) {
+        self.help = Some(note.into());
     }
 
     /// Set the help message of this report.
-    pub fn with_help<N: ToString>(mut self, note: N) -> Self {
+    pub fn with_help<N: Into<String>>(mut self, note: N) -> Self {
         self.set_help(note);
         self
     }


### PR DESCRIPTION
The rationale is that if the user already has a `String`, using
`ToString` will unnecessarily clone the `String` instead of assigning it
directly.