### PR TITLE
Removing magic numbers from color generator

### DIFF
--- a/src/draw.rs
+++ b/src/draw.rs
@@ -121,20 +121,49 @@ impl<T: fmt::Display> fmt::Display for Background<T> {
 
 /// A type that can generate distinct 8-bit colors.
 pub struct ColorGenerator {
-    state: [u16; 3],
+    state: [u16; Self::MAX_AMOUNT_STATES],
     min_brightness: f32,
 }
 
 impl Default for ColorGenerator {
-    fn default() -> Self { Self::from_state([30000, 15000, 35000], 0.5) }
+    fn default() -> Self {
+        Self::from_state(
+            [
+                Self::DEFAULT_MIN_COLOR,
+                Self::DEFAULT_COLOR_STEP,
+                Self::DEFAULT_MAX_COLOR,
+            ],
+            Self::DEFAULT_BRIGHTNESS,
+        )
+    }
 }
 
 impl ColorGenerator {
+    /// the minimal brightness value
+    pub const MIN_BRIGHTNESS: f32 = 0.0;
+
+    /// the maximal brightness value
+    pub const MAX_BRIGHTNESS: f32 = 1.0;
+
+    /// the default brightness
+    pub const DEFAULT_BRIGHTNESS: f32 = 0.5;
+
+    const MAX_AMOUNT_STATES: usize = 3;
+
+    const DEFAULT_MIN_COLOR: u16 = 30_000;
+    const DEFAULT_COLOR_STEP: u16 = 15_000;
+    const DEFAULT_MAX_COLOR: u16 = 35_000;
+
     /// Create a new [`ColorGenerator`] with the given pre-chosen state.
     ///
     /// The minimum brightness can be used to control the colour brightness (0.0 - 1.0). The default is 0.5.
-    pub fn from_state(state: [u16; 3], min_brightness: f32) -> Self {
-        Self { state, min_brightness: min_brightness.max(0.0).min(1.0) }
+    pub fn from_state(state: [u16; Self::MAX_AMOUNT_STATES], min_brightness: f32) -> Self {
+        Self {
+            state,
+            min_brightness: min_brightness
+                .max(Self::MIN_BRIGHTNESS)
+                .min(Self::MAX_BRIGHTNESS),
+        }
     }
 
     /// Create a new [`ColorGenerator`] with the default state.
@@ -144,13 +173,20 @@ impl ColorGenerator {
 
     /// Generate the next colour in the sequence.
     pub fn next(&mut self) -> Color {
-        for i in 0..3 {
+        for i in 0..Self::MAX_AMOUNT_STATES {
             // magic constant, one of only two that have this property!
             self.state[i] = (self.state[i] as usize).wrapping_add(40503 * (i * 4 + 1130)) as u16;
         }
-        Color::Fixed(16
-            + ((self.state[2] as f32 / 65535.0 * (1.0 - self.min_brightness) + self.min_brightness) * 5.0
-            + (self.state[1] as f32 / 65535.0 * (1.0 - self.min_brightness) + self.min_brightness) * 30.0
-            + (self.state[0] as f32 / 65535.0 * (1.0 - self.min_brightness) + self.min_brightness) * 180.0) as u8)
+        Color::Fixed(
+            16 + ((self.state[2] as f32 / 65535.0 * (1.0 - self.min_brightness)
+                + self.min_brightness)
+                * 5.0
+                + (self.state[1] as f32 / 65535.0 * (1.0 - self.min_brightness)
+                    + self.min_brightness)
+                    * 30.0
+                + (self.state[0] as f32 / 65535.0 * (1.0 - self.min_brightness)
+                    + self.min_brightness)
+                    * 180.0) as u8,
+        )
     }
 }

--- a/src/draw.rs
+++ b/src/draw.rs
@@ -139,11 +139,11 @@ impl Default for ColorGenerator {
 }
 
 impl ColorGenerator {
-    /// the minimal brightness value
-    pub const MIN_BRIGHTNESS: f32 = 0.0;
+    /// the minimal possible brightness value
+    pub const MIN_BRIGHTNESS_VALUE: f32 = 0.0;
 
-    /// the maximal brightness value
-    pub const MAX_BRIGHTNESS: f32 = 1.0;
+    /// the maximal possible brightness value
+    pub const MAX_BRIGHTNESS_VALUE: f32 = 1.0;
 
     /// the default brightness
     pub const DEFAULT_BRIGHTNESS: f32 = 0.5;
@@ -161,8 +161,8 @@ impl ColorGenerator {
         Self {
             state,
             min_brightness: min_brightness
-                .max(Self::MIN_BRIGHTNESS)
-                .min(Self::MAX_BRIGHTNESS),
+                .max(Self::MIN_BRIGHTNESS_VALUE)
+                .min(Self::MAX_BRIGHTNESS_VALUE),
         }
     }
 
@@ -178,13 +178,16 @@ impl ColorGenerator {
             self.state[i] = (self.state[i] as usize).wrapping_add(40503 * (i * 4 + 1130)) as u16;
         }
         Color::Fixed(
-            16 + ((self.state[2] as f32 / 65535.0 * (1.0 - self.min_brightness)
+            16 + ((self.state[2] as f32 / 65535.0
+                * (Self::MAX_BRIGHTNESS_VALUE - self.min_brightness)
                 + self.min_brightness)
                 * 5.0
-                + (self.state[1] as f32 / 65535.0 * (1.0 - self.min_brightness)
+                + (self.state[1] as f32 / 65535.0
+                    * (Self::MAX_BRIGHTNESS_VALUE - self.min_brightness)
                     + self.min_brightness)
                     * 30.0
-                + (self.state[0] as f32 / 65535.0 * (1.0 - self.min_brightness)
+                + (self.state[0] as f32 / 65535.0
+                    * (Self::MAX_BRIGHTNESS_VALUE - self.min_brightness)
                     + self.min_brightness)
                     * 180.0) as u8,
         )


### PR DESCRIPTION
I'd like to change the constant numbers with constant variable names to make it easier to understand those constant numbers in the color generator. But I don't fully understand what your calculations are doing here:

- https://github.com/zesterer/ariadne/blob/main/src/draw.rs#L149
- https://github.com/zesterer/ariadne/blob/main/src/draw.rs#L152
- https://github.com/zesterer/ariadne/blob/main/src/draw.rs#L153
- https://github.com/zesterer/ariadne/blob/main/src/draw.rs#L154

Do you agree to move those constants to variables/constants?