### PR TITLE
Relax 'static lifetime on custom ReportKind name

### DIFF
--- a/src/write.rs
+++ b/src/write.rs
@@ -24,7 +24,7 @@ struct SourceGroup<'a, S: Span> {
     labels: Vec<LabelInfo<'a, S>>,
 }
 
-impl<S: Span> Report<S> {
+impl<S: Span> Report<'_, S> {
     fn get_source_groups(&self, cache: &mut impl Cache<S::SourceId>) -> Vec<SourceGroup<S>> {
         let mut groups = Vec::new();
         for label in self.labels.iter() {


### PR DESCRIPTION
I'm in the process of writing a Python wrapper for `ariadne`, but `ReportKind::Custom` has a member with a `'static` lifetime, making it impossible to use across FFI boundaries. This change relaxes the `'static` lifetime, making it possible to use ReportKind::Custom across FFI.