### PR TITLE
Add support for unicode width

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,3 +16,4 @@ exclude = [
 
 [dependencies]
 yansi = "0.5"
+unicode-width = "0.1.9"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,6 +21,7 @@ use std::{
     cmp::{PartialEq, Eq},
     fmt,
 };
+use unicode_width::UnicodeWidthChar;
 
 /// A trait implemented by spans within a character-based source.
 pub trait Span {
@@ -369,7 +370,7 @@ impl Config {
                 (' ',  tab_end - col)
             },
             c if c.is_whitespace() => (' ', 1),
-            _ => (c, 1),
+            _ => (c, c.width().unwrap_or(1)),
         }
     }
 }

--- a/src/write.rs
+++ b/src/write.rs
@@ -459,9 +459,14 @@ impl<S: Span> Report<'_, S> {
                             self.config.unimportant_color()
                         };
                         let (c, width) = self.config.char_width(c, col);
-                        for _ in 0..width {
+                        if c.is_whitespace() {
+                            for _ in 0..width {
+                                write!(w, "{}", c.fg(color))?;
+                            }
+                        } else {
                             write!(w, "{}", c.fg(color))?;
-                        }
+                        };
+
                     }
                 }
                 write!(w, "\n")?;


### PR DESCRIPTION
In just testing some byte offset to char index conversion code, I noticed 
https://github.com/zesterer/ariadne/issues/41 

When testing with "🦀".
Naively just modifying `char_width()` prints multiple instances of the unicode character in question.
"🦀" becomes "🦀🦀", 

I left this behavior enabled for whitespace since I believe it is a part of the treatment of '\t' tab characters.

This perhaps doesn't fully fix the issue as reported, they might need a boolean to `Config` setting, which sets things up to call either `width` and `width_cjk`, but I don't know the right behavior to shoot for regarding whitespace in cjk.