### PR TITLE
proposal: add `Report::with_labels`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -263,6 +263,12 @@ impl<'a, S: Span> ReportBuilder<'a, S> {
         self.add_label(label);
         self
     }
+    
+    /// Add multiple labels to the report.
+    pub fn with_labels<L: IntoIterator<Item = Label<S>>>(mut self, labels: L) -> Self {
+        self.add_labels(labels);
+        self
+    }
 
     /// Use the given [`Config`] to determine diagnostic attributes.
     pub fn with_config(mut self, config: Config) -> Self {


### PR DESCRIPTION
This PR adds `Report::with_labels`, a chainable equivalent of `Report::add_labels`. This brings a minor DX improvement for the common use case where a report includes an iterable of errors, such as when parsing input with chumsky.

Before

```rust
if let Err(errors) = parser().parse(&input) {
    let mut report =
        Report::build(ReportKind::Error, &filename, 0).with_message("Error parsing file");
    report.add_labels(errors.iter().map(|error| {
        Label::new((&filename, error.span())).with_message(format!("{}", error))
    }));
    report
        .finish()
        .eprint((&filename, Source::from(&input)))
        .unwrap();
}
```

After

```rust
if let Err(errors) = parser().parse(&input) {
    Report::build(ReportKind::Error, &filename, 0)
        .with_message("Error parsing file");
        .with_labels(errors.iter().map(|error| {
            Label::new((&filename, error.span())).with_message(format!("{}", error))
        }))
        .finish()
        .eprint((&filename, Source::from(&input)))
        .unwrap();
}
```