### PR TITLE
Add concolor integration feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,10 @@ exclude = [
 	"/misc/*",
 ]
 
+[features]
+auto-color = ["concolor", "concolor/auto"]
+
 [dependencies]
 yansi = "0.5"
 unicode-width = "0.1.9"
+concolor = { version = "0.0.11", optional = true }

--- a/README.md
+++ b/README.md
@@ -88,6 +88,26 @@ you're thinking of using `ariadne` to process your compiler's output, why not tr
 - A plethora of other options (tab width, label attach points, underlines, etc.)
 - Built-in ordering/overlap heuristics that come up with the best way to avoid overlapping & label crossover
 
+## Cargo Features
+
+- `"concolor"` enables integration with the [`concolor`](https://crates.io/crates/concolor) crate for global color output
+  control across your application
+- `"auto-color"` enables `concolor`'s `"auto"` feature for automatic color control
+
+`concolor`'s features should be defined by the top-level binary crate, but without any features enabled `concolor` does
+nothing. If `ariadne` is your only dependency using `concolor` then `"auto-color"` provides a convenience to enable
+`concolor`'s automatic color support detection, i.e. this:
+```TOML
+[dependencies]
+ariadne = { version = "...", features = ["auto-color"] }
+```
+is equivalent to this:
+```TOML
+[dependencies]
+ariadne = { version = "...", features = ["concolor"] }
+concolor = { version = "...", features = ["auto"] }
+```
+
 ## Planned Features
 
 - Improved layout planning & space usage

--- a/src/draw.rs
+++ b/src/draw.rs
@@ -78,22 +78,118 @@ impl Characters {
     }
 }
 
+/// Output stream to check for whether color is enabled.
+#[derive(Clone, Copy, Debug)]
+pub enum StreamType {
+    /// Standard Output
+    Stdout,
+    /// Standard Error
+    Stderr,
+}
+
+#[cfg(feature = "concolor")]
+impl From<StreamType> for concolor::Stream {
+    fn from(s: StreamType) -> Self {
+        match s {
+            StreamType::Stdout => concolor::Stream::Stdout,
+            StreamType::Stderr => concolor::Stream::Stderr,
+        }
+    }
+}
+
+/// A trait used to add formatting attributes to displayable items intended to be written to a
+/// particular stream (`stdout` or `stderr`).
+///
+/// Attributes specified through this trait are not composable (i.e: the behaviour of two nested attributes each with a
+/// conflicting attribute is left unspecified).
+pub trait StreamAwareFmt: Sized {
+    #[cfg(feature = "concolor")]
+    /// Returns true if color is enabled for the given stream.
+    fn color_enabled_for(s: StreamType) -> bool {
+        concolor::get(s.into()).color()
+    }
+
+    #[cfg(not(feature = "concolor"))]
+    #[doc(hidden)]
+    fn color_enabled_for(_: StreamType) -> bool {
+        true
+    }
+
+    /// Give this value the specified foreground colour, when color is enabled for the specified stream.
+    fn fg<C: Into<Option<Color>>>(self, color: C, stream: StreamType) -> Foreground<Self> {
+        if Self::color_enabled_for(stream) {
+            Foreground(self, color.into())
+        } else {
+            Foreground(self, None)
+        }
+    }
+
+    /// Give this value the specified background colour, when color is enabled for the specified stream.
+    fn bg<C: Into<Option<Color>>>(self, color: C, stream: StreamType) -> Background<Self> {
+        if Self::color_enabled_for(stream) {
+            Background(self, color.into())
+        } else {
+            Background(self, None)
+        }
+    }
+}
+
+impl<T: fmt::Display> StreamAwareFmt for T {}
+
 /// A trait used to add formatting attributes to displayable items.
+///
+/// If using the `concolor` feature, this trait assumes that the items are going to be printed to
+/// `stderr`. If you are printing to `stdout`, `use` the [`StdoutFmt`] trait instead.
 ///
 /// Attributes specified through this trait are not composable (i.e: the behaviour of two nested attributes each with a
 /// conflicting attribute is left unspecified).
 pub trait Fmt: Sized {
-    /// Give this value the specified foreground colour
-    fn fg<C: Into<Option<Color>>>(self, color: C) -> Foreground<Self> {
-        Foreground(self, color.into())
+    /// Give this value the specified foreground colour.
+    fn fg<C: Into<Option<Color>>>(self, color: C) -> Foreground<Self>
+    where
+        Self: fmt::Display,
+    {
+        if cfg!(feature = "concolor") {
+            StreamAwareFmt::fg(self, color, StreamType::Stderr)
+        } else {
+            Foreground(self, color.into())
+        }
     }
 
-    /// Give this value the specified background colour
-    fn bg<C: Into<Option<Color>>>(self, color: C) -> Background<Self> {
-        Background(self, color.into())
+    /// Give this value the specified background colour.
+    fn bg<C: Into<Option<Color>>>(self, color: C) -> Background<Self>
+    where
+        Self: fmt::Display,
+    {
+        if cfg!(feature = "concolor") {
+            StreamAwareFmt::bg(self, color, StreamType::Stdout)
+        } else {
+            Background(self, color.into())
+        }
     }
 }
+
 impl<T: fmt::Display> Fmt for T {}
+
+/// A trait used to add formatting attributes to displayable items intended to be written to `stdout`.
+///
+/// Attributes specified through this trait are not composable (i.e: the behaviour of two nested attributes each with a
+/// conflicting attribute is left unspecified).
+#[cfg(any(feature = "concolor", doc))]
+pub trait StdoutFmt: StreamAwareFmt {
+    /// Give this value the specified foreground colour, when color is enabled for `stdout`.
+    fn fg<C: Into<Option<Color>>>(self, color: C) -> Foreground<Self> {
+        StreamAwareFmt::fg(self, color, StreamType::Stdout)
+    }
+
+    /// Give this value the specified background colour, when color is enabled for `stdout`.
+    fn bg<C: Into<Option<Color>>>(self, color: C) -> Background<Self> {
+        StreamAwareFmt::bg(self, color, StreamType::Stdout)
+    }
+}
+
+#[cfg(feature = "concolor")]
+impl<T: fmt::Display> StdoutFmt for T {}
 
 #[derive(Copy, Clone, Debug)]
 pub struct Foreground<T>(T, Option<Color>);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,9 +12,11 @@ pub use crate::{
 };
 pub use yansi::Color;
 
+#[cfg(any(feature = "concolor", doc))]
+pub use crate::draw::StdoutFmt;
+
 use crate::display::*;
 use std::{
-    borrow::Borrow,
     ops::Range,
     io::{self, Write},
     hash::Hash,
@@ -167,7 +169,7 @@ impl<S: Span> Report<'_, S> {
     /// In most cases, [`Report::eprint`] is the
     /// ['more correct'](https://en.wikipedia.org/wiki/Standard_streams#Standard_error_(stderr)) function to use.
     pub fn print<C: Cache<S::SourceId>>(&self, cache: C) -> io::Result<()> {
-        self.write(cache, io::stdout())
+        self.write_for_stdout(cache, io::stdout())
     }
 }
 


### PR DESCRIPTION
I started writing my own trait to wrap `ariadne::Fmt` to turn coloring on and off using `concolor` and then thought, why not push it upstream? I've made it an optional feature for backwards compatibility.

For the purposes of `concolor`'s interactive terminal detection I've assumed that existing projects are writing to `stderr` but if they're not, they can switch to `stdout` by doing `use ariadne::StdoutFmt` instead of `use ariadne::Fmt`.