### PR TITLE
Derive some common traits

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -67,6 +67,7 @@ impl<Id: fmt::Debug + Hash + PartialEq + Eq + ToOwned> Span for (Id, Range<usize
 }
 
 /// A type that represents a labelled section of source code.
+#[derive(Clone, Debug, Hash, PartialEq, Eq)]
 pub struct Label<S = Range<usize>> {
     span: S,
     msg: Option<String>,

--- a/src/source.rs
+++ b/src/source.rs
@@ -30,6 +30,7 @@ impl<C: Cache<Id>, Id: ?Sized> Cache<Id> for Box<C> {
 }
 
 /// A type representing a single line of a [`Source`].
+#[derive(Clone, Debug, Hash, PartialEq, Eq)]
 pub struct Line {
     offset: usize,
     len: usize,
@@ -53,6 +54,7 @@ impl Line {
 /// A type representing a single source that may be referred to by [`Span`]s.
 ///
 /// In most cases, a source is a single input file.
+#[derive(Clone, Debug, Hash, PartialEq, Eq)]
 pub struct Source {
     lines: Vec<Line>,
     len: usize,


### PR DESCRIPTION
Derive common traits on some of the simple structs in the crate. I have a use case where I need `Source` instances to be comparable (for use in a [salsa](https://docs.rs/salsa)-based project), and this should do the trick.

(I havent applied the traits to other useful things like `Report` which require more complicated bounds. I could do it if you'd prefer that)