### PR TITLE
Implement common traits for Report(Builder), FileCache, FnCache

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -171,6 +171,18 @@ impl<S: Span> Report<'_, S> {
     }
 }
 
+impl<'a, S: Span> fmt::Debug for Report<'a, S> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Report")
+            .field("kind", &self.kind)
+            .field("code", &self.code)
+            .field("msg", &self.msg)
+            .field("note", &self.note)
+            .field("help", &self.help)
+            .field("config", &self.config)
+            .finish()
+    }
+}
 /// A type that defines the kind of report being produced.
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub enum ReportKind<'a> {
@@ -289,6 +301,19 @@ impl<'a, S: Span> ReportBuilder<'a, S> {
             labels: self.labels,
             config: self.config,
         }
+    }
+}
+
+impl<'a, S: Span> fmt::Debug for ReportBuilder<'a, S> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("ReportBuilder")
+            .field("kind", &self.kind)
+            .field("code", &self.code)
+            .field("msg", &self.msg)
+            .field("note", &self.note)
+            .field("help", &self.help)
+            .field("config", &self.config)
+            .finish()
     }
 }
 

--- a/src/source.rs
+++ b/src/source.rs
@@ -140,14 +140,9 @@ impl<Id: fmt::Display + Eq> Cache<Id> for (Id, Source) {
 }
 
 /// A [`Cache`] that fetches [`Source`]s from the filesystem.
+#[derive(Default, Debug, Clone)]
 pub struct FileCache {
     files: HashMap<PathBuf, Source>,
-}
-
-impl Default for FileCache {
-    fn default() -> Self {
-        Self { files: HashMap::default() }
-    }
 }
 
 impl Cache<Path> for FileCache {

--- a/src/source.rs
+++ b/src/source.rs
@@ -156,6 +156,7 @@ impl Cache<Path> for FileCache {
 }
 
 /// A [`Cache`] that fetches [`Source`]s using the provided function.
+#[derive(Debug, Clone)]
 pub struct FnCache<Id, F> {
     sources: HashMap<Id, Source>,
     get: F,


### PR DESCRIPTION
For the caches, some traits can just be derived. For `Report` and `ReportBuilder`, we need to implement `Debug` by hand because the fields `location` and `labels` prevent us from deriving it. These fields are simply skipped in the `Debug` impl for now.