### PR TITLE
Update concolor version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,4 +20,4 @@ auto-color = ["concolor", "concolor/auto"]
 [dependencies]
 yansi = "0.5"
 unicode-width = "0.1.9"
-concolor = { version = "0.0.11", optional = true }
+concolor = { version = "0.1", optional = true }


### PR DESCRIPTION
The last version of concolor breaks compatibility with `v0.11.0`, so when I try to enable or disable colors in my aplication, ariadne doesn't get the correct setting. Updating to the latest version fixes the issue.