### PR TITLE
Remove extra vertical space for any label with no message set

### DIFF
--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -16,9 +16,9 @@ fn main() {
         .with_message("Incompatible types")
         .with_config(Config::default().with_compact(true))
         .with_label(Label::new(0..1).with_color(Color::Red))
-        .with_label(Label::new(2..3).with_color(Color::Blue).with_message("This is another test").with_order(1))
+        .with_label(Label::new(2..3).with_color(Color::Blue).with_message("`b` for banana").with_order(1))
         .with_label(Label::new(4..5).with_color(Color::Green))
-        .with_label(Label::new(7..9).with_color(Color::Cyan).with_message("This is a test"))
+        .with_label(Label::new(7..9).with_color(Color::Cyan).with_message("`e` for emerald"))
         .finish()
         .print(Source::from(SOURCE))
         .unwrap();

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -1,4 +1,5 @@
-use ariadne::{Report, ReportKind, Label, Source};
+use yansi::Color;
+use ariadne::{Report, ReportKind, Label, Source, Config};
 
 fn main() {
     Report::build(ReportKind::Error, (), 34)
@@ -7,5 +8,18 @@ fn main() {
         .with_label(Label::new(42..45).with_message("This is of type Str"))
         .finish()
         .print(Source::from(include_str!("sample.tao")))
+        .unwrap();
+
+    const SOURCE: &str = "a b c d e f";
+    // also supports labels with no messages to only emphasis on some areas
+    Report::build(ReportKind::Error, (), 34)
+        .with_message("Incompatible types")
+        .with_config(Config::default().with_compact(true))
+        .with_label(Label::new(0..1).with_color(Color::Red))
+        .with_label(Label::new(2..3).with_color(Color::Blue).with_message("This is another test").with_order(1))
+        .with_label(Label::new(4..5).with_color(Color::Green))
+        .with_label(Label::new(7..9).with_color(Color::Cyan).with_message("This is a test"))
+        .finish()
+        .print(Source::from(SOURCE))
         .unwrap();
 }

--- a/src/write.rs
+++ b/src/write.rs
@@ -608,7 +608,10 @@ impl<S: Span> Report<'_, S> {
                 // Arrows
                 for row in 0..line_labels.len() {
                     let line_label = &line_labels[row];
-
+                    //No message to draw thus no arrow to draw
+                    if line_label.label.msg.is_none() {
+                        continue
+                    }
                     if !self.config.compact {
                         // Margin alternate
                         write_margin(


### PR DESCRIPTION
Hello @zesterer !
There is an issue where the library stills draw extra spaces for labels with no messages, the library still allocate a line regardless if the label has an arrow to display.

This was reported by @kaikalii in #51, adding a check here seems to fix the issue.

https://github.com/zesterer/ariadne/blob/8225799605ac9831107d4d8ccb8f85f5609bea71/src/write.rs#L606-L609

__however__ there's still some issues with multiline labels, i need you to determine how this can be handled : 

![image](https://github.com/zesterer/ariadne/assets/67809972/c9a02ec2-649c-499b-9810-bbaac348a9b5)

Also, i could'nt find an efficient way to write tests for this PR, thus i allowed myself to add a new example to prove the fix.
![image](https://github.com/zesterer/ariadne/assets/67809972/e7dd2176-caa9-45f9-a2a8-60428da3b127)

other examples 
![image](https://github.com/zesterer/ariadne/assets/67809972/bb99d855-15be-4b0c-9748-8c16ebe413e9)


* fixes #51 