### PR TITLE
Fix invalid unicode character for uarrow

### DIFF
--- a/src/draw.rs
+++ b/src/draw.rs
@@ -36,7 +36,7 @@ impl Characters {
             xbar: '┼',
             vbar_break: '┆',
             vbar_gap: '┆',
-            uarrow: '🭯',
+            uarrow: '▲',
             rarrow: '▶',
             ltop: '╭',
             mtop: '┬',


### PR DESCRIPTION
Chose BLACK UP-POINTING TRIANGLE to match existing BLACK RIGHT-POINTING TRIANGLE which is used for rarrow.

Great crate BTW, thanks!