### PR TITLE
Fix FileCache

### DIFF
--- a/src/source.rs
+++ b/src/source.rs
@@ -213,18 +213,17 @@ pub struct FileCache {
     files: HashMap<PathBuf, Source>,
 }
 
-impl Cache<Path> for FileCache {
+impl Cache<&Path> for FileCache {
     type Storage = String;
 
-    fn fetch(&mut self, path: &Path) -> Result<&Source, Box<dyn fmt::Debug + '_>> {
+    fn fetch(&mut self, path: &&Path) -> Result<&Source, Box<dyn fmt::Debug + '_>> {
         Ok(match self.files.entry(path.to_path_buf()) { // TODO: Don't allocate here
             Entry::Occupied(entry) => entry.into_mut(),
             Entry::Vacant(entry) => entry.insert(Source::from(fs::read_to_string(path).map_err(|e| Box::new(e) as _)?)),
         })
     }
-    fn display<'a>(&self, path: &'a Path) -> Option<Box<dyn fmt::Display + 'a>> { Some(Box::new(path.display())) }
+    fn display<'a>(&self, path: &&'a Path) -> Option<Box<dyn fmt::Display + 'a>> { Some(Box::new(path.display())) }
 }
-
 /// A [`Cache`] that fetches [`Source`]s using the provided function.
 #[derive(Debug, Clone)]
 pub struct FnCache<Id, F, I>


### PR DESCRIPTION
As reported in #40, `FileCache` isn't usable, as it only implements `Cache<Path>`. However, as cache is unsized, it's impossible to actually pass in a `Path`, making `FileCache` unusable. This PR just changes the implementation to use `&Path` instead. In my quick testing, it appears to now work without any issues.