### PR TITLE
Expose Source text

### DIFF
--- a/src/source.rs
+++ b/src/source.rs
@@ -74,6 +74,13 @@ pub struct Source<I: AsRef<str> = String> {
     len: usize,
 }
 
+impl<I: AsRef<str>> Source<I> {
+    /// Get the full text of this source file.
+    pub fn text(&self) -> &str {
+        self.text.as_ref()
+    }
+}
+
 impl<I: AsRef<str>> From<I> for Source<I> {
     /// Generate a [`Source`] from the given [`str`].
     ///


### PR DESCRIPTION
# Use Case

_Please correct if there's a less dumb way of doing this!_

I'm using a custom `Cache` implementation, and would like to maintain a single `Id` --> `Source` map. This doesn't work today because there's no way for non-Ariadne consumers like a parser to access `Source::text`. Exposing it makes `Source` immediately useful for non-Ariadne applications.