### PR TITLE
Fix crashes when using Byte Spans. 

### DIFF
--- a/src/source.rs
+++ b/src/source.rs
@@ -212,9 +212,9 @@ impl<I: AsRef<str>> Source<I> {
         start..end
     }
 
-    /// Get the source text for a line, excluding trailing whitespace.
+    /// Get the source text for a line, includes trailing whitespace and the newline
     pub fn get_line_text(&self, line: Line) -> Option<&'_ str> {
-        self.text.as_ref().get(line.byte_span()).map(|text| text.trim_end())
+        self.text.as_ref().get(line.byte_span())
     }
 }
 
@@ -335,7 +335,7 @@ mod tests {
             assert_eq!(source_line.char_len, raw_line.chars().count());
             assert_eq!(
                 source.get_line_text(source_line).unwrap(),
-                raw_line.trim_end()
+                raw_line
             );
             offset += source_line.char_len;
         }
@@ -398,7 +398,7 @@ mod tests {
             assert_eq!(source_line.char_len, raw_line.chars().count());
             assert_eq!(
                 source.get_line_text(source_line).unwrap(),
-                raw_line.trim_end()
+                raw_line
             );
             offset += source_line.char_len;
         }

--- a/src/write.rs
+++ b/src/write.rs
@@ -81,7 +81,7 @@ impl<S: Span> Report<'_, S> {
                         // We can subtract 1 from end, because get_byte_line doesn't actually index into the text. 
                         let end_pos = given_label_span.end - 1;
                         let Some((end_line_obj, end_line, end_byte_col)) = src.get_byte_line(end_pos) else {continue};
-                        let end_line_text = src.get_line_text(start_line_obj).unwrap();
+                        let end_line_text = src.get_line_text(end_line_obj).unwrap();
                         // Have to add 1 back now, so we don't cut a char in two. 
                         let num_chars_before_end = end_line_text[..end_byte_col+1].chars().count();
                         let end_char_offset = end_line_obj.offset() + num_chars_before_end;

--- a/src/write.rs
+++ b/src/write.rs
@@ -1012,8 +1012,8 @@ mod tests {
     fn byte_spans_never_crash() {
         let source = "apple\np\n\nempty\n";
 
-        for i in 0..source.len() {
-            for j in i..source.len() {
+        for i in 0..=source.len() {
+            for j in i..=source.len() {
                 let _ = Report::<Range<usize>>::build(ReportKind::Error, (), 0)
                     .with_config(no_color_and_ascii().with_index_type(IndexType::Byte))
                     .with_message("Label")


### PR DESCRIPTION
This pull request does include a breaking change, namely Source::get_line_text now returns the full line, including trailing whitespace and newline. 

It also includes a new test, ensuring that no possible byte span in a small excerpt causes a crash. 