### PR TITLE
Adding more styling options for users

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /target
 Cargo.lock
+.idea

--- a/src/draw.rs
+++ b/src/draw.rs
@@ -53,6 +53,30 @@ impl Characters {
         }
     }
 
+    pub fn unicode_straight() -> Self {
+        Self {
+            hbar: '─',
+            vbar: '│',
+            xbar: '┼',
+            vbar_break: '┆',
+            vbar_gap: '┆',
+            uarrow: '▲',
+            rarrow: '▶',
+            ltop: '┌',
+            mtop: '┬',
+            rtop: '┐',
+            lbot: '└',
+            mbot: '┴',
+            rbot: '┘',
+            lbox: '[',
+            rbox: ']',
+            lcross: '├',
+            rcross: '┤',
+            underbar: '┬',
+            underline: '─',
+        }
+    }
+
     pub fn ascii() -> Self {
         Self {
             hbar: '-',

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -354,6 +354,8 @@ pub enum LabelAttach {
 pub enum CharSet {
     /// Unicode characters (an attempt is made to use only commonly-supported characters).
     Unicode,
+    /// Unicode characters for box drawing, using straight lines instead of curved ones.
+    UnicodeStraight,
     /// ASCII-only characters.
     Ascii,
 }

--- a/src/write.rs
+++ b/src/write.rs
@@ -149,6 +149,7 @@ impl<S: Span> Report<'_, S> {
     ) -> io::Result<()> {
         let draw = match self.config.char_set {
             CharSet::Unicode => draw::Characters::unicode(),
+            CharSet::UnicodeStraight => draw::Characters::unicode_straight(),
             CharSet::Ascii => draw::Characters::ascii(),
         };
 
@@ -1184,4 +1185,51 @@ mod tests {
         ---'
         "###)
     }
+
+    #[test]
+    fn unicode_style() {
+        let source = "apple == orange;";
+        let msg = Report::<Range<usize>>::build(ReportKind::Error, (), 0)
+            .with_config(Config::default().with_char_set(CharSet::Unicode).with_color(false))
+            .with_message("can't compare apples with oranges")
+            .with_label(Label::new(0..5).with_message("This is an apple"))
+            .with_label(Label::new(9..15).with_message("This is an orange"))
+            .finish()
+            .write_to_string(Source::from(source));
+        assert_snapshot!(msg, @r###"
+        Error: can't compare apples with oranges
+           ╭─[<unknown>:1:1]
+           │
+         1 │ apple == orange;
+           │ ──┬──    ───┬──  
+           │   ╰────────────── This is an apple
+           │             │    
+           │             ╰──── This is an orange
+        ───╯
+        "###)
+    }
+
+        #[test]
+    fn unicode_stright_style() {
+        let source = "apple == orange;";
+        let msg = Report::<Range<usize>>::build(ReportKind::Error, (), 0)
+            .with_config(Config::default().with_char_set(CharSet::UnicodeStraight).with_color(false))
+            .with_message("can't compare apples with oranges")
+            .with_label(Label::new(0..5).with_message("This is an apple"))
+            .with_label(Label::new(9..15).with_message("This is an orange"))
+            .finish()
+            .write_to_string(Source::from(source));
+        assert_snapshot!(msg, @r###"
+        Error: can't compare apples with oranges
+           ┌─[<unknown>:1:1]
+           │
+         1 │ apple == orange;
+           │ ──┬──    ───┬──  
+           │   └────────────── This is an apple
+           │             │    
+           │             └──── This is an orange
+        ───┘
+        "###)
+    }
 }
+


### PR DESCRIPTION
# Abstract

This pull request introduces the capability to use straight box drawing characters in addition to the existing curved ones. This enhancement broadens the range of visual styles available to users, allowing for greater flexibility and customization in graphical representations.

## Background
Currently, our system supports only curved box drawing characters. While these are suitable for many applications, they can sometimes appear too stylized for use cases requiring a sharper, more angular aesthetic. Recognizing this limitation, this update provides an alternative that caters to different stylistic preferences and practical requirements.

## Implementation Details
The implementation extends the existing functionality to include straight line variants of the box drawing characters. This is achieved by adding a new enumeration option, `CharSet::UnicodeStraight`, which users can select to switch from curved to straight line rendering. This option is designed to integrate seamlessly with the existing framework, ensuring that users can easily toggle between character styles without compatibility issues.

### Also Includes
- Changes to the `.gitignore` to allow for better support for users of the Jetbrains IDEs
- Tests for both `CharSet::Unicode` & `CharSet::UnicodeStright` 

## Impact
By enabling the use of straight box drawing characters, this feature enhances the toolkit available to users, making it more adaptable to various design needs. It particularly benefits applications in design, text-based art, and user interface development, where line aesthetics can play a crucial role in user experience and information clarity.

# Example
```
Error: can't compare apples with oranges
   ┌─[<unknown>:1:1]
   │
 1 │ apple == orange;
   │ ──┬──    ───┬──  
   │   └────────────── This is an apple
   │             │    
   │             └──── This is an orange
───┘
```
 
