### PR TITLE
Chore: `cargo clippy` and `cargo fmt`

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -8,6 +8,7 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
+  RUST_VERSION: 1.77.1
 
 jobs:
   build:
@@ -20,3 +21,28 @@ jobs:
       run: cargo build --verbose
     - name: Run tests
       run: cargo test --verbose
+
+  cargo-fmt-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install toolchain
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ env.RUST_VERSION }}
+          components: rustfmt
+      - name: Check Formatting
+        run: cargo fmt --all -- --check
+
+  cargo-clippy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install toolchain
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ env.RUST_VERSION }}
+          components: clippy
+      - uses: Swatinem/rust-cache@v2
+      - name: Check Clippy Linter
+        run: cargo clippy --all-features --all-targets -- -D warnings

--- a/examples/multifile.rs
+++ b/examples/multifile.rs
@@ -1,4 +1,4 @@
-use ariadne::{Report, ReportKind, Label, ColorGenerator, Fmt, sources};
+use ariadne::{sources, ColorGenerator, Fmt, Label, Report, ReportKind};
 
 fn main() {
     let mut colors = ColorGenerator::new();
@@ -10,21 +10,36 @@ fn main() {
 
     Report::build(ReportKind::Error, "b.tao", 10)
         .with_code(3)
-        .with_message(format!("Cannot add types Nat and Str"))
-        .with_label(Label::new(("b.tao", 10..14))
-            .with_message(format!("This is of type {}", "Nat".fg(a)))
-            .with_color(a))
-        .with_label(Label::new(("b.tao", 17..20))
-            .with_message(format!("This is of type {}", "Str".fg(b)))
-            .with_color(b))
-        .with_label(Label::new(("b.tao", 15..16))
-            .with_message(format!(" {} and {} undergo addition here", "Nat".fg(a), "Str".fg(b)))
-            .with_color(c)
-            .with_order(10))
-        .with_label(Label::new(("a.tao", 4..8))
-            .with_message(format!("Original definition of {} is here", "five".fg(a)))
-            .with_color(a))
-        .with_note(format!("{} is a number and can only be added to other numbers", "Nat".fg(a)))
+        .with_message("Cannot add types Nat and Str".to_string())
+        .with_label(
+            Label::new(("b.tao", 10..14))
+                .with_message(format!("This is of type {}", "Nat".fg(a)))
+                .with_color(a),
+        )
+        .with_label(
+            Label::new(("b.tao", 17..20))
+                .with_message(format!("This is of type {}", "Str".fg(b)))
+                .with_color(b),
+        )
+        .with_label(
+            Label::new(("b.tao", 15..16))
+                .with_message(format!(
+                    " {} and {} undergo addition here",
+                    "Nat".fg(a),
+                    "Str".fg(b)
+                ))
+                .with_color(c)
+                .with_order(10),
+        )
+        .with_label(
+            Label::new(("a.tao", 4..8))
+                .with_message(format!("Original definition of {} is here", "five".fg(a)))
+                .with_color(a),
+        )
+        .with_note(format!(
+            "{} is a number and can only be added to other numbers",
+            "Nat".fg(a)
+        ))
         .finish()
         .print(sources(vec![
             ("a.tao", include_str!("a.tao")),

--- a/examples/multiline.rs
+++ b/examples/multiline.rs
@@ -1,4 +1,4 @@
-use ariadne::{Report, ReportKind, Label, Source, Color, ColorGenerator, Fmt};
+use ariadne::{Color, ColorGenerator, Fmt, Label, Report, ReportKind, Source};
 
 fn main() {
     let mut colors = ColorGenerator::new();
@@ -7,36 +7,43 @@ fn main() {
     let a = colors.next();
     let b = colors.next();
     let out = Color::Fixed(81);
-    let out2= colors.next();
+    let out2 = colors.next();
 
     Report::build(ReportKind::Error, "sample.tao", 12)
         .with_code(3)
-        .with_message(format!("Incompatible types"))
-        .with_label(Label::new(("sample.tao", 32..33))
-            .with_message(format!("This is of type {}", "Nat".fg(a)))
-            .with_color(a))
-        .with_label(Label::new(("sample.tao", 42..45))
-            .with_message(format!("This is of type {}", "Str".fg(b)))
-            .with_color(b))
-        .with_label(Label::new(("sample.tao", 11..48))
-            .with_message(format!(
-                "The values are outputs of this {} expression",
-                "match".fg(out),
-            ))
-            .with_color(out))
-        .with_label(Label::new(("sample.tao", 0..48))
-            .with_message(format!(
-                "The {} has a problem",
-                "definition".fg(out2),
-            ))
-            .with_color(out2))
-        .with_label(Label::new(("sample.tao", 50..76))
-            .with_message(format!(
-                "Usage of {} here",
-                "definition".fg(out2),
-            ))
-            .with_color(out2))
-        .with_note(format!("Outputs of {} expressions must coerce to the same type", "match".fg(out)))
+        .with_message("Incompatible types".to_string())
+        .with_label(
+            Label::new(("sample.tao", 32..33))
+                .with_message(format!("This is of type {}", "Nat".fg(a)))
+                .with_color(a),
+        )
+        .with_label(
+            Label::new(("sample.tao", 42..45))
+                .with_message(format!("This is of type {}", "Str".fg(b)))
+                .with_color(b),
+        )
+        .with_label(
+            Label::new(("sample.tao", 11..48))
+                .with_message(format!(
+                    "The values are outputs of this {} expression",
+                    "match".fg(out),
+                ))
+                .with_color(out),
+        )
+        .with_label(
+            Label::new(("sample.tao", 0..48))
+                .with_message(format!("The {} has a problem", "definition".fg(out2),))
+                .with_color(out2),
+        )
+        .with_label(
+            Label::new(("sample.tao", 50..76))
+                .with_message(format!("Usage of {} here", "definition".fg(out2),))
+                .with_color(out2),
+        )
+        .with_note(format!(
+            "Outputs of {} expressions must coerce to the same type",
+            "match".fg(out)
+        ))
         .finish()
         .print(("sample.tao", Source::from(include_str!("sample.tao"))))
         .unwrap();

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -1,4 +1,4 @@
-use ariadne::{Report, ReportKind, Label, Source, Config, Color};
+use ariadne::{Color, Config, Label, Report, ReportKind, Source};
 
 fn main() {
     Report::build(ReportKind::Error, (), 34)
@@ -15,9 +15,18 @@ fn main() {
         .with_message("Incompatible types")
         .with_config(Config::default().with_compact(true))
         .with_label(Label::new(0..1).with_color(Color::Red))
-        .with_label(Label::new(2..3).with_color(Color::Blue).with_message("`b` for banana").with_order(1))
+        .with_label(
+            Label::new(2..3)
+                .with_color(Color::Blue)
+                .with_message("`b` for banana")
+                .with_order(1),
+        )
         .with_label(Label::new(4..5).with_color(Color::Green))
-        .with_label(Label::new(7..9).with_color(Color::Cyan).with_message("`e` for emerald"))
+        .with_label(
+            Label::new(7..9)
+                .with_color(Color::Cyan)
+                .with_message("`e` for emerald"),
+        )
         .finish()
         .print(Source::from(SOURCE))
         .unwrap();

--- a/examples/stresstest.rs
+++ b/examples/stresstest.rs
@@ -1,59 +1,227 @@
-use ariadne::{Report, ReportKind, Label, Source, Config, Color, ColorGenerator};
+use ariadne::{Color, ColorGenerator, Config, Label, Report, ReportKind, Source};
 
 fn main() {
     let mut colors = ColorGenerator::new();
 
     Report::build(ReportKind::Error, "stresstest.tao", 13)
         .with_code(3)
-        .with_message(format!("Incompatible types"))
-        .with_label(Label::new(("stresstest.tao", 0..1)).with_message("Color").with_color(colors.next()))
-        .with_label(Label::new(("stresstest.tao", 1..2)).with_message("Color").with_color(colors.next()))
-        .with_label(Label::new(("stresstest.tao", 2..3)).with_message("Color").with_color(colors.next()))
-        .with_label(Label::new(("stresstest.tao", 3..4)).with_message("Color").with_color(colors.next()))
-        .with_label(Label::new(("stresstest.tao", 4..5)).with_message("Color").with_color(colors.next()))
-        .with_label(Label::new(("stresstest.tao", 5..6)).with_message("Color").with_color(colors.next()))
-        .with_label(Label::new(("stresstest.tao", 6..7)).with_message("Color").with_color(colors.next()))
-        .with_label(Label::new(("stresstest.tao", 7..8)).with_message("Color").with_color(colors.next()))
-        .with_label(Label::new(("stresstest.tao", 8..9)).with_message("Color").with_color(colors.next()))
-        .with_label(Label::new(("stresstest.tao", 9..10)).with_message("Color").with_color(colors.next()))
-        .with_label(Label::new(("stresstest.tao", 10..11)).with_message("Color").with_color(colors.next()))
-        .with_label(Label::new(("stresstest.tao", 11..12)).with_message("Color").with_color(colors.next()))
-        .with_label(Label::new(("stresstest.tao", 12..13)).with_message("Color").with_color(colors.next()))
-        .with_label(Label::new(("stresstest.tao", 13..14)).with_message("Color").with_color(colors.next()))
-        .with_label(Label::new(("stresstest.tao", 14..15)).with_message("Color").with_color(colors.next()))
-        .with_label(Label::new(("stresstest.tao", 15..16)).with_message("Color").with_color(colors.next()))
-        .with_label(Label::new(("stresstest.tao", 16..17)).with_message("Color").with_color(colors.next()))
-        .with_label(Label::new(("stresstest.tao", 17..18)).with_message("Color").with_color(colors.next()))
-        .with_label(Label::new(("stresstest.tao", 18..19)).with_message("Color").with_color(colors.next()))
-        .with_label(Label::new(("stresstest.tao", 19..20)).with_message("Color").with_color(colors.next()))
-        .with_label(Label::new(("stresstest.tao", 20..21)).with_message("Color").with_color(colors.next()))
-
-        .with_label(Label::new(("stresstest.tao", 18..19)).with_message("This is of type Nat").with_color(colors.next()))
-        .with_label(Label::new(("stresstest.tao", 13..16)).with_message("This is of type Str").with_color(colors.next()))
-        .with_label(Label::new(("stresstest.tao", 40..41)).with_message("This is of type Nat").with_color(colors.next()))
-        .with_label(Label::new(("stresstest.tao", 43..47)).with_message("This is of type Bool").with_color(colors.next()))
-        .with_label(Label::new(("stresstest.tao", 49..51)).with_message("This is of type ()").with_color(colors.next()))
-        .with_label(Label::new(("stresstest.tao", 53..55)).with_message("This is of type [_]").with_color(colors.next()))
-        .with_label(Label::new(("stresstest.tao", 25..78)).with_message("This is of type Str").with_color(colors.next()))
-        .with_label(Label::new(("stresstest.tao", 81..124)).with_message("This is of type Nat").with_color(colors.next()))
-        .with_label(Label::new(("stresstest.tao", 100..126)).with_message("This is an inner multi-line").with_color(colors.next()))
-        .with_label(Label::new(("stresstest.tao", 106..120)).with_message("This is another inner multi-line").with_color(colors.next()))
-        .with_label(Label::new(("stresstest.tao", 108..122)).with_message("This is *really* nested multi-line").with_color(colors.next()))
-        .with_label(Label::new(("stresstest.tao", 110..111)).with_message("This is an inline within the nesting!").with_color(colors.next()))
-        .with_label(Label::new(("stresstest.tao", 111..112)).with_message("And another!").with_color(colors.next()))
-        .with_label(Label::new(("stresstest.tao", 103..123)).with_message("This is *really* nested multi-line").with_color(colors.next()))
-        .with_label(Label::new(("stresstest.tao", 105..125)).with_message("This is *really* nested multi-line").with_color(colors.next()))
-        .with_label(Label::new(("stresstest.tao", 112..116)).with_message("This is *really* nested multi-line").with_color(colors.next()))
-        .with_label(Label::new(("stresstest.tao", 26..100)).with_message("Hahaha!").with_color(Color::Fixed(75)))
-        .with_label(Label::new(("stresstest.tao", 85..110)).with_message("Oh god, no more 1").with_color(colors.next()))
-        .with_label(Label::new(("stresstest.tao", 84..114)).with_message("Oh god, no more 2").with_color(colors.next()))
-        .with_label(Label::new(("stresstest.tao", 89..113)).with_message("Oh god, no more 3").with_color(colors.next()))
-        .with_config(Config::default()
-            .with_cross_gap(false)
-            .with_compact(true)
-            .with_underlines(true)
-            .with_tab_width(4))
+        .with_message("Incompatible types".to_string())
+        .with_label(
+            Label::new(("stresstest.tao", 0..1))
+                .with_message("Color")
+                .with_color(colors.next()),
+        )
+        .with_label(
+            Label::new(("stresstest.tao", 1..2))
+                .with_message("Color")
+                .with_color(colors.next()),
+        )
+        .with_label(
+            Label::new(("stresstest.tao", 2..3))
+                .with_message("Color")
+                .with_color(colors.next()),
+        )
+        .with_label(
+            Label::new(("stresstest.tao", 3..4))
+                .with_message("Color")
+                .with_color(colors.next()),
+        )
+        .with_label(
+            Label::new(("stresstest.tao", 4..5))
+                .with_message("Color")
+                .with_color(colors.next()),
+        )
+        .with_label(
+            Label::new(("stresstest.tao", 5..6))
+                .with_message("Color")
+                .with_color(colors.next()),
+        )
+        .with_label(
+            Label::new(("stresstest.tao", 6..7))
+                .with_message("Color")
+                .with_color(colors.next()),
+        )
+        .with_label(
+            Label::new(("stresstest.tao", 7..8))
+                .with_message("Color")
+                .with_color(colors.next()),
+        )
+        .with_label(
+            Label::new(("stresstest.tao", 8..9))
+                .with_message("Color")
+                .with_color(colors.next()),
+        )
+        .with_label(
+            Label::new(("stresstest.tao", 9..10))
+                .with_message("Color")
+                .with_color(colors.next()),
+        )
+        .with_label(
+            Label::new(("stresstest.tao", 10..11))
+                .with_message("Color")
+                .with_color(colors.next()),
+        )
+        .with_label(
+            Label::new(("stresstest.tao", 11..12))
+                .with_message("Color")
+                .with_color(colors.next()),
+        )
+        .with_label(
+            Label::new(("stresstest.tao", 12..13))
+                .with_message("Color")
+                .with_color(colors.next()),
+        )
+        .with_label(
+            Label::new(("stresstest.tao", 13..14))
+                .with_message("Color")
+                .with_color(colors.next()),
+        )
+        .with_label(
+            Label::new(("stresstest.tao", 14..15))
+                .with_message("Color")
+                .with_color(colors.next()),
+        )
+        .with_label(
+            Label::new(("stresstest.tao", 15..16))
+                .with_message("Color")
+                .with_color(colors.next()),
+        )
+        .with_label(
+            Label::new(("stresstest.tao", 16..17))
+                .with_message("Color")
+                .with_color(colors.next()),
+        )
+        .with_label(
+            Label::new(("stresstest.tao", 17..18))
+                .with_message("Color")
+                .with_color(colors.next()),
+        )
+        .with_label(
+            Label::new(("stresstest.tao", 18..19))
+                .with_message("Color")
+                .with_color(colors.next()),
+        )
+        .with_label(
+            Label::new(("stresstest.tao", 19..20))
+                .with_message("Color")
+                .with_color(colors.next()),
+        )
+        .with_label(
+            Label::new(("stresstest.tao", 20..21))
+                .with_message("Color")
+                .with_color(colors.next()),
+        )
+        .with_label(
+            Label::new(("stresstest.tao", 18..19))
+                .with_message("This is of type Nat")
+                .with_color(colors.next()),
+        )
+        .with_label(
+            Label::new(("stresstest.tao", 13..16))
+                .with_message("This is of type Str")
+                .with_color(colors.next()),
+        )
+        .with_label(
+            Label::new(("stresstest.tao", 40..41))
+                .with_message("This is of type Nat")
+                .with_color(colors.next()),
+        )
+        .with_label(
+            Label::new(("stresstest.tao", 43..47))
+                .with_message("This is of type Bool")
+                .with_color(colors.next()),
+        )
+        .with_label(
+            Label::new(("stresstest.tao", 49..51))
+                .with_message("This is of type ()")
+                .with_color(colors.next()),
+        )
+        .with_label(
+            Label::new(("stresstest.tao", 53..55))
+                .with_message("This is of type [_]")
+                .with_color(colors.next()),
+        )
+        .with_label(
+            Label::new(("stresstest.tao", 25..78))
+                .with_message("This is of type Str")
+                .with_color(colors.next()),
+        )
+        .with_label(
+            Label::new(("stresstest.tao", 81..124))
+                .with_message("This is of type Nat")
+                .with_color(colors.next()),
+        )
+        .with_label(
+            Label::new(("stresstest.tao", 100..126))
+                .with_message("This is an inner multi-line")
+                .with_color(colors.next()),
+        )
+        .with_label(
+            Label::new(("stresstest.tao", 106..120))
+                .with_message("This is another inner multi-line")
+                .with_color(colors.next()),
+        )
+        .with_label(
+            Label::new(("stresstest.tao", 108..122))
+                .with_message("This is *really* nested multi-line")
+                .with_color(colors.next()),
+        )
+        .with_label(
+            Label::new(("stresstest.tao", 110..111))
+                .with_message("This is an inline within the nesting!")
+                .with_color(colors.next()),
+        )
+        .with_label(
+            Label::new(("stresstest.tao", 111..112))
+                .with_message("And another!")
+                .with_color(colors.next()),
+        )
+        .with_label(
+            Label::new(("stresstest.tao", 103..123))
+                .with_message("This is *really* nested multi-line")
+                .with_color(colors.next()),
+        )
+        .with_label(
+            Label::new(("stresstest.tao", 105..125))
+                .with_message("This is *really* nested multi-line")
+                .with_color(colors.next()),
+        )
+        .with_label(
+            Label::new(("stresstest.tao", 112..116))
+                .with_message("This is *really* nested multi-line")
+                .with_color(colors.next()),
+        )
+        .with_label(
+            Label::new(("stresstest.tao", 26..100))
+                .with_message("Hahaha!")
+                .with_color(Color::Fixed(75)),
+        )
+        .with_label(
+            Label::new(("stresstest.tao", 85..110))
+                .with_message("Oh god, no more 1")
+                .with_color(colors.next()),
+        )
+        .with_label(
+            Label::new(("stresstest.tao", 84..114))
+                .with_message("Oh god, no more 2")
+                .with_color(colors.next()),
+        )
+        .with_label(
+            Label::new(("stresstest.tao", 89..113))
+                .with_message("Oh god, no more 3")
+                .with_color(colors.next()),
+        )
+        .with_config(
+            Config::default()
+                .with_cross_gap(false)
+                .with_compact(true)
+                .with_underlines(true)
+                .with_tab_width(4),
+        )
         .finish()
-        .print(("stresstest.tao", Source::from(include_str!("stresstest.tao"))))
+        .print((
+            "stresstest.tao",
+            Source::from(include_str!("stresstest.tao")),
+        ))
         .unwrap();
 }

--- a/src/display.rs
+++ b/src/display.rs
@@ -14,8 +14,8 @@ impl<T: Display> Display for Show<Option<T>> {
 
 impl<'a, T, F: Fn(&mut fmt::Formatter, &'a T) -> fmt::Result> Display for Show<(&'a [T], F)> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        for x in self.0.0 {
-            (self.0.1)(f, x)?;
+        for x in self.0 .0 {
+            (self.0 .1)(f, x)?;
         }
         Ok(())
     }
@@ -23,8 +23,8 @@ impl<'a, T, F: Fn(&mut fmt::Formatter, &'a T) -> fmt::Result> Display for Show<(
 
 impl<T: Display> Display for Show<(T, usize)> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        for _ in 0..self.0.1 {
-            write!(f, "{}", self.0.0)?;
+        for _ in 0..self.0 .1 {
+            write!(f, "{}", self.0 .0)?;
         }
         Ok(())
     }

--- a/src/draw.rs
+++ b/src/draw.rs
@@ -222,7 +222,9 @@ pub struct ColorGenerator {
 }
 
 impl Default for ColorGenerator {
-    fn default() -> Self { Self::from_state([30000, 15000, 35000], 0.5) }
+    fn default() -> Self {
+        Self::from_state([30000, 15000, 35000], 0.5)
+    }
 }
 
 impl ColorGenerator {
@@ -230,7 +232,10 @@ impl ColorGenerator {
     ///
     /// The minimum brightness can be used to control the colour brightness (0.0 - 1.0). The default is 0.5.
     pub fn from_state(state: [u16; 3], min_brightness: f32) -> Self {
-        Self { state, min_brightness: min_brightness.max(0.0).min(1.0) }
+        Self {
+            state,
+            min_brightness: min_brightness.max(0.0).min(1.0),
+        }
     }
 
     /// Create a new [`ColorGenerator`] with the default state.
@@ -239,14 +244,22 @@ impl ColorGenerator {
     }
 
     /// Generate the next colour in the sequence.
+    #[allow(clippy::should_implement_trait)]
     pub fn next(&mut self) -> Color {
         for i in 0..3 {
             // magic constant, one of only two that have this property!
             self.state[i] = (self.state[i] as usize).wrapping_add(40503 * (i * 4 + 1130)) as u16;
         }
-        Color::Fixed(16
-            + ((self.state[2] as f32 / 65535.0 * (1.0 - self.min_brightness) + self.min_brightness) * 5.0
-            + (self.state[1] as f32 / 65535.0 * (1.0 - self.min_brightness) + self.min_brightness) * 30.0
-            + (self.state[0] as f32 / 65535.0 * (1.0 - self.min_brightness) + self.min_brightness) * 180.0) as u8)
+        Color::Fixed(
+            16 + ((self.state[2] as f32 / 65535.0 * (1.0 - self.min_brightness)
+                + self.min_brightness)
+                * 5.0
+                + (self.state[1] as f32 / 65535.0 * (1.0 - self.min_brightness)
+                    + self.min_brightness)
+                    * 30.0
+                + (self.state[0] as f32 / 65535.0 * (1.0 - self.min_brightness)
+                    + self.min_brightness)
+                    * 180.0) as u8,
+        )
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -530,6 +530,7 @@ impl Default for Config {
 
 #[test]
 #[should_panic]
+#[allow(clippy::reversed_empty_ranges)]
 fn backwards_label_should_panic() {
     Label::new(1..0);
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,14 +1,14 @@
 #![doc = include_str!("../README.md")]
 #![deny(missing_docs)]
 
-mod source;
 mod display;
 mod draw;
+mod source;
 mod write;
 
 pub use crate::{
-    source::{Line, Source, Cache, FileCache, FnCache, sources},
-    draw::{Fmt, ColorGenerator},
+    draw::{ColorGenerator, Fmt},
+    source::{sources, Cache, FileCache, FnCache, Line, Source},
 };
 pub use yansi::Color;
 
@@ -17,11 +17,11 @@ pub use crate::draw::StdoutFmt;
 
 use crate::display::*;
 use std::{
-    ops::Range,
-    io::{self, Write},
-    hash::Hash,
-    cmp::{PartialEq, Eq},
+    cmp::{Eq, PartialEq},
     fmt,
+    hash::Hash,
+    io::{self, Write},
+    ops::Range,
 };
 use unicode_width::UnicodeWidthChar;
 
@@ -46,26 +46,47 @@ pub trait Span {
     fn end(&self) -> usize;
 
     /// Get the length of this span (difference between the start of the span and the end of the span).
-    fn len(&self) -> usize { self.end().saturating_sub(self.start()) }
+    fn len(&self) -> usize {
+        self.end().saturating_sub(self.start())
+    }
+
+    /// Returns `true` if this span has length zero.
+    fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
 
     /// Determine whether the span contains the given offset.
-    fn contains(&self, offset: usize) -> bool { (self.start()..self.end()).contains(&offset) }
+    fn contains(&self, offset: usize) -> bool {
+        (self.start()..self.end()).contains(&offset)
+    }
 }
 
 impl Span for Range<usize> {
     type SourceId = ();
 
-    fn source(&self) -> &Self::SourceId { &() }
-    fn start(&self) -> usize { self.start }
-    fn end(&self) -> usize { self.end }
+    fn source(&self) -> &Self::SourceId {
+        &()
+    }
+    fn start(&self) -> usize {
+        self.start
+    }
+    fn end(&self) -> usize {
+        self.end
+    }
 }
 
 impl<Id: fmt::Debug + Hash + PartialEq + Eq + ToOwned> Span for (Id, Range<usize>) {
     type SourceId = Id;
 
-    fn source(&self) -> &Self::SourceId { &self.0 }
-    fn start(&self) -> usize { self.1.start }
-    fn end(&self) -> usize { self.1.end }
+    fn source(&self) -> &Self::SourceId {
+        &self.0
+    }
+    fn start(&self) -> usize {
+        self.1.start
+    }
+    fn end(&self) -> usize {
+        self.1.end
+    }
 }
 
 /// A type that represents the way a label should be displayed.
@@ -92,19 +113,16 @@ impl<S: Span> Label<S> {
     ///
     /// Panics if the given span is backwards.
     pub fn new(span: S) -> Self {
-        assert!(
-            span.start() <= span.end(),
-            "Label start is after its end"
-        );
+        assert!(span.start() <= span.end(), "Label start is after its end");
 
         Self {
             span,
-            display_info: LabelDisplay{
+            display_info: LabelDisplay {
                 msg: None,
                 color: None,
                 order: 0,
                 priority: 0,
-            }
+            },
         }
     }
 
@@ -164,7 +182,11 @@ pub struct Report<'a, S: Span = Range<usize>> {
 
 impl<S: Span> Report<'_, S> {
     /// Begin building a new [`Report`].
-    pub fn build<Id: Into<<S::SourceId as ToOwned>::Owned>>(kind: ReportKind, src_id: Id, offset: usize) -> ReportBuilder<S> {
+    pub fn build<Id: Into<<S::SourceId as ToOwned>::Owned>>(
+        kind: ReportKind,
+        src_id: Id,
+        offset: usize,
+    ) -> ReportBuilder<S> {
         ReportBuilder {
             kind,
             code: None,
@@ -289,7 +311,10 @@ impl<'a, S: Span> ReportBuilder<'a, S> {
     /// Add multiple labels to the report.
     pub fn add_labels<L: IntoIterator<Item = Label<S>>>(&mut self, labels: L) {
         let config = &self.config; // This would not be necessary in Rust 2021 edition
-        self.labels.extend(labels.into_iter().map(|mut label| { label.display_info.color = config.filter_color(label.display_info.color); label }));
+        self.labels.extend(labels.into_iter().map(|mut label| {
+            label.display_info.color = config.filter_color(label.display_info.color);
+            label
+        }));
     }
 
     /// Add a label to the report.
@@ -378,7 +403,7 @@ pub struct Config {
     color: bool,
     tab_width: usize,
     char_set: CharSet,
-    index_type : IndexType,
+    index_type: IndexType,
 }
 
 impl Config {
@@ -387,48 +412,91 @@ impl Config {
     /// The alternative to this is to insert crossing characters. However, these interact poorly with label colours.
     ///
     /// If unspecified, this defaults to [`false`].
-    pub fn with_cross_gap(mut self, cross_gap: bool) -> Self { self.cross_gap = cross_gap; self }
+    pub fn with_cross_gap(mut self, cross_gap: bool) -> Self {
+        self.cross_gap = cross_gap;
+        self
+    }
     /// Where should inline labels attach to their spans?
     ///
     /// If unspecified, this defaults to [`LabelAttach::Middle`].
-    pub fn with_label_attach(mut self, label_attach: LabelAttach) -> Self { self.label_attach = label_attach; self }
+    pub fn with_label_attach(mut self, label_attach: LabelAttach) -> Self {
+        self.label_attach = label_attach;
+        self
+    }
     /// Should the report remove gaps to minimise used space?
     ///
     /// If unspecified, this defaults to [`false`].
-    pub fn with_compact(mut self, compact: bool) -> Self { self.compact = compact; self }
+    pub fn with_compact(mut self, compact: bool) -> Self {
+        self.compact = compact;
+        self
+    }
     /// Should underlines be used for label span where possible?
     ///
     /// If unspecified, this defaults to [`true`].
-    pub fn with_underlines(mut self, underlines: bool) -> Self { self.underlines = underlines; self }
+    pub fn with_underlines(mut self, underlines: bool) -> Self {
+        self.underlines = underlines;
+        self
+    }
     /// Should arrows be used to point to the bounds of multi-line spans?
     ///
     /// If unspecified, this defaults to [`true`].
-    pub fn with_multiline_arrows(mut self, multiline_arrows: bool) -> Self { self.multiline_arrows = multiline_arrows; self }
+    pub fn with_multiline_arrows(mut self, multiline_arrows: bool) -> Self {
+        self.multiline_arrows = multiline_arrows;
+        self
+    }
     /// Should colored output should be enabled?
     ///
     /// If unspecified, this defaults to [`true`].
-    pub fn with_color(mut self, color: bool) -> Self { self.color = color; self }
+    pub fn with_color(mut self, color: bool) -> Self {
+        self.color = color;
+        self
+    }
     /// How many characters width should tab characters be?
     ///
     /// If unspecified, this defaults to `4`.
-    pub fn with_tab_width(mut self, tab_width: usize) -> Self { self.tab_width = tab_width; self }
+    pub fn with_tab_width(mut self, tab_width: usize) -> Self {
+        self.tab_width = tab_width;
+        self
+    }
     /// What character set should be used to display dynamic elements such as boxes and arrows?
     ///
     /// If unspecified, this defaults to [`CharSet::Unicode`].
-    pub fn with_char_set(mut self, char_set: CharSet) -> Self { self.char_set = char_set; self }
+    pub fn with_char_set(mut self, char_set: CharSet) -> Self {
+        self.char_set = char_set;
+        self
+    }
     /// Should this report use byte spans instead of char spans?
     ///
     /// If unspecified, this defaults to 'false'
-    pub fn with_index_type(mut self, index_type : IndexType) -> Self { self.index_type = index_type; self }
+    pub fn with_index_type(mut self, index_type: IndexType) -> Self {
+        self.index_type = index_type;
+        self
+    }
 
-    fn error_color(&self) -> Option<Color> { Some(Color::Red).filter(|_| self.color) }
-    fn warning_color(&self) -> Option<Color> { Some(Color::Yellow).filter(|_| self.color) }
-    fn advice_color(&self) -> Option<Color> { Some(Color::Fixed(147)).filter(|_| self.color) }
-    fn margin_color(&self) -> Option<Color> { Some(Color::Fixed(246)).filter(|_| self.color) }
-    fn skipped_margin_color(&self) -> Option<Color> { Some(Color::Fixed(240)).filter(|_| self.color) }
-    fn unimportant_color(&self) -> Option<Color> { Some(Color::Fixed(249)).filter(|_| self.color) }
-    fn note_color(&self) -> Option<Color> { Some(Color::Fixed(115)).filter(|_| self.color) }
-    fn filter_color(&self, color: Option<Color>) -> Option<Color> { color.filter(|_| self.color) }
+    fn error_color(&self) -> Option<Color> {
+        Some(Color::Red).filter(|_| self.color)
+    }
+    fn warning_color(&self) -> Option<Color> {
+        Some(Color::Yellow).filter(|_| self.color)
+    }
+    fn advice_color(&self) -> Option<Color> {
+        Some(Color::Fixed(147)).filter(|_| self.color)
+    }
+    fn margin_color(&self) -> Option<Color> {
+        Some(Color::Fixed(246)).filter(|_| self.color)
+    }
+    fn skipped_margin_color(&self) -> Option<Color> {
+        Some(Color::Fixed(240)).filter(|_| self.color)
+    }
+    fn unimportant_color(&self) -> Option<Color> {
+        Some(Color::Fixed(249)).filter(|_| self.color)
+    }
+    fn note_color(&self) -> Option<Color> {
+        Some(Color::Fixed(115)).filter(|_| self.color)
+    }
+    fn filter_color(&self, color: Option<Color>) -> Option<Color> {
+        color.filter(|_| self.color)
+    }
 
     // Find the character that should be drawn and the number of times it should be drawn for each char
     fn char_width(&self, c: char, col: usize) -> (char, usize) {
@@ -436,8 +504,8 @@ impl Config {
             '\t' => {
                 // Find the column that the tab should end at
                 let tab_end = (col / self.tab_width + 1) * self.tab_width;
-                (' ',  tab_end - col)
-            },
+                (' ', tab_end - col)
+            }
             c if c.is_whitespace() => (' ', 1),
             _ => (c, c.width().unwrap_or(1)),
         }

--- a/src/write.rs
+++ b/src/write.rs
@@ -723,7 +723,20 @@ impl<S: Span> Report<'_, S> {
                             let underline = get_underline(col).filter(|_| row == 0);
                             let [c, tail] = if let Some(vbar_ll) = vbar {
                                 let [c, tail] = if underline.is_some() {
-                                    [draw.underbar, draw.underline]
+                                    // TODO: Is this good?
+                                    // The `true` is used here because it's temporarily disabling a
+                                    // feature that might be reenabled later.
+                                    #[allow(clippy::overly_complex_bool_expr)]
+                                    if ExactSizeIterator::len(&vbar_ll.label.char_span) <= 1 || true
+                                    {
+                                        [draw.underbar, draw.underline]
+                                    } else if line.offset() + col == vbar_ll.label.char_span.start {
+                                        [draw.ltop, draw.underbar]
+                                    } else if line.offset() + col == vbar_ll.label.last_offset() {
+                                        [draw.rtop, draw.underbar]
+                                    } else {
+                                        [draw.underbar, draw.underline]
+                                    }
                                 } else if vbar_ll.multi && row == 0 && self.config.multiline_arrows
                                 {
                                     [draw.uarrow, ' ']


### PR DESCRIPTION
Runs `cargo fmt` and `cargo clippy` and fixes any issues that came up. It also adds those two steps to CI.

This is just a suggestion so feel free to close this PR. I just find it a good practice to make sure both tools are run with every PR to improve code quality.