### PR TITLE
Show underlines even when first label has no message

### DIFF
--- a/src/write.rs
+++ b/src/write.rs
@@ -706,11 +706,9 @@ impl<S: Span> Report<'_, S> {
                 // Arrows
                 for row in 0..line_labels.len() {
                     let line_label = &line_labels[row];
-                    //No message to draw thus no arrow to draw
-                    if line_label.label.display_info.msg.is_none() {
-                        continue;
-                    }
-                    if !self.config.compact {
+                    if (line_label.label.display_info.msg.is_some() || row == 0)
+                        && !self.config.compact
+                    {
                         // Margin alternate
                         write_margin(
                             &mut w,
@@ -767,6 +765,11 @@ impl<S: Span> Report<'_, S> {
                             }
                         }
                         writeln!(w)?;
+                    }
+
+                    // No message to draw thus no arrow to draw
+                    if line_label.label.display_info.msg.is_none() {
+                        continue;
                     }
 
                     // Margin
@@ -947,12 +950,12 @@ mod tests {
             .with_label(Label::new(9..15))
             .finish()
             .write_to_string(Source::from(source));
-        // TODO: it would be nice if these spans still showed up (like codespan-reporting does)
         assert_snapshot!(msg, @r###"
         Error: can't compare apples with oranges
            ,-[<unknown>:1:1]
            |
          1 | apple == orange;
+           | ^^^^^    ^^^^^^  
         ---'
         "###);
     }


### PR DESCRIPTION
In ariadne v0.3.0, any label would cause its span to be underlined, but also add blank lines to the output even when it had no message.

In v0.4.0, the extraneous blank lines were removed, but the behaviour regarding underlines was also changed: When the first label has no message set, *no* underlines at all are shown:
```rust
    const SOURCE: &str = "a b c d e f";
    // also supports labels with no messages to only emphasis on some areas
    Report::build(ReportKind::Error, (), 34)
        .with_message("Incompatible types")
        .with_label(Label::new(0..1).with_color(Color::Red))
        .with_label(
            Label::new(2..3)
                .with_color(Color::Blue)
                .with_message("`b` for banana")
                .with_order(1),
        )
        .with_label(Label::new(4..5).with_color(Color::Green))
        .with_label(
            Label::new(7..9)
                .with_color(Color::Cyan)
                .with_message("`e` for emerald"),
        )
        .finish()
        .print(Source::from(SOURCE))
        .unwrap();
```
(Based on `examples/simple.rs` without `compact`.)

This will show 
```
Error: Incompatible types
   ╭─[<unknown>:?:?]
   │
 1 │ a b c d e f
   │   │     │
   │   │     ╰── `e` for emerald
   │   │
   │   ╰──────── `b` for banana
───╯
```
But when the first label for `a` has a message, all spans have underlines:
```
Error: Incompatible types
   ╭─[<unknown>:?:?]
   │
 1 │ a b c d e f
   │ ┬ ┬ ─  ─┬
   │ ╰────────── a
   │   │     │
   │   │     ╰── `e` for emerald
   │   │
   │   ╰──────── `b` for banana
───╯
```
With this PR, underlines will be shown regardless of whether the first label has a message:
```
Error: Incompatible types
   ╭─[<unknown>:?:?]
   │
 1 │ a b c d e f
   │ ─ ┬ ─  ─┬
   │   │     │
   │   │     ╰── `e` for emerald
   │   │
   │   ╰──────── `b` for banana
───╯
```