### PR TITLE
Annotate `Report` and `ReportBuilder` with `#[must_use]`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -169,6 +169,7 @@ impl<S: Span> Label<S> {
 }
 
 /// A type representing a diagnostic that is ready to be written to output.
+#[must_use = "call `.print()` or `.eprint()` to print the report"]
 pub struct Report<'a, S: Span = Range<usize>> {
     kind: ReportKind<'a>,
     code: Option<String>,
@@ -252,6 +253,7 @@ impl fmt::Display for ReportKind<'_> {
 }
 
 /// A type used to build a [`Report`].
+#[must_use = "call `.finish()` to obtain a `Report`"]
 pub struct ReportBuilder<'a, S: Span> {
     kind: ReportKind<'a>,
     code: Option<String>,


### PR DESCRIPTION
This ensures that one doesn't forget to call `.finish()` or `.eprint()`