### PR TITLE
Add display line offset

### DIFF
--- a/src/source.rs
+++ b/src/source.rs
@@ -94,6 +94,7 @@ pub struct Source<I: AsRef<str> = String> {
     lines: Vec<Line>,
     len: usize,
     byte_len: usize,
+    display_line_offset: usize,
 }
 
 impl<I: AsRef<str>> Source<I> {
@@ -121,6 +122,7 @@ impl<I: AsRef<str>> From<I> for Source<I> {
                 }],
                 len: 0,
                 byte_len: 0,
+                display_line_offset: 0,
             };
         }
 
@@ -162,11 +164,23 @@ impl<I: AsRef<str>> From<I> for Source<I> {
             lines,
             len: char_offset,
             byte_len: byte_offset,
+            display_line_offset: 0,
         }
     }
 }
 
 impl<I: AsRef<str>> Source<I> {
+    /// Add an offset to the printed line numbers
+    pub fn with_display_line_offset(mut self, offset: usize) -> Self {
+        self.display_line_offset = offset;
+        self
+    }
+
+    /// Get the offset added to printed line numbers
+    pub fn display_line_offset(&self) -> usize {
+        self.display_line_offset
+    }
+
     /// Get the length of the total number of characters in the source.
     pub fn len(&self) -> usize {
         self.len

--- a/src/write.rs
+++ b/src/write.rs
@@ -258,7 +258,12 @@ impl<S: Span> Report<'_, S> {
                 }),
             };
             let (line_no, col_no) = line_and_col
-                .map(|(_, idx, col)| (format!("{}", idx + 1), format!("{}", col + 1)))
+                .map(|(_, idx, col)| {
+                    (
+                        format!("{}", idx + 1 + src.display_line_offset()),
+                        format!("{}", col + 1),
+                    )
+                })
                 .unwrap_or_else(|| ('?'.to_string(), '?'.to_string()));
             let line_ref = format!(":{}:{}", line_no, col_no);
             writeln!(


### PR DESCRIPTION
This is an alternative to https://github.com/zesterer/ariadne/pull/7 and also closes https://github.com/zesterer/ariadne/issues/6. I think this implementation is a bit simpler and hopefully easier to review.

To reiterate the use case. I have code like this:
```rust
#[test]
fn some_test() {
    parse_with_ariadne_errors("
       <some custom programming language here>
    ")
}
```
Now if ariadne prints an error for that test, I want it to give me the line number 3, not 1, because I want to know where the error is _in the file_, not _in the string_. I then automatically add the line number with a macro. I hope that makes sense. This has been super helpful for me :)

If the other implementation is preferred I could also adopt that PR and fix it up based on the feedback there.