### PR TITLE
Remove Report/ReportKind lifetime

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ fn main() {
     let b = colors.next();
     let out = Color::Fixed(81);
 
-    Report::build(ReportKind::Error, ("sample.tao", 12..12))
+    Report::build(ErrorKind, ("sample.tao", 12..12))
         .with_code(3)
         .with_message(format!("Incompatible types"))
         .with_label(

--- a/examples/multifile.rs
+++ b/examples/multifile.rs
@@ -1,4 +1,4 @@
-use ariadne::{sources, ColorGenerator, Fmt, Label, Report, ReportKind};
+use ariadne::{sources, ColorGenerator, ErrorKind, Fmt, Label, Report};
 
 fn main() {
     let mut colors = ColorGenerator::new();
@@ -8,7 +8,7 @@ fn main() {
     let b = colors.next();
     let c = colors.next();
 
-    Report::build(ReportKind::Error, ("b.tao", 10..14))
+    Report::build(ErrorKind, ("b.tao", 10..14))
         .with_code(3)
         .with_message("Cannot add types Nat and Str".to_string())
         .with_label(

--- a/examples/multiline.rs
+++ b/examples/multiline.rs
@@ -1,4 +1,4 @@
-use ariadne::{Color, ColorGenerator, Fmt, Label, Report, ReportKind, Source};
+use ariadne::{Color, ColorGenerator, ErrorKind, Fmt, Label, Report, Source};
 
 fn main() {
     let mut colors = ColorGenerator::new();
@@ -9,7 +9,7 @@ fn main() {
     let out = Color::Fixed(81);
     let out2 = colors.next();
 
-    Report::build(ReportKind::Error, ("sample.tao", 32..33))
+    Report::build(ErrorKind, ("sample.tao", 32..33))
         .with_code(3)
         .with_message("Incompatible types".to_string())
         .with_label(

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -1,7 +1,7 @@
-use ariadne::{Color, Config, Label, Report, ReportKind, Source};
+use ariadne::{Color, Config, ErrorKind, Label, Report, Source};
 
 fn main() {
-    Report::build(ReportKind::Error, 34..34)
+    Report::build(ErrorKind, 34..34)
         .with_message("Incompatible types")
         .with_label(Label::new(32..33).with_message("This is of type Nat"))
         .with_label(Label::new(42..45).with_message("This is of type Str"))
@@ -11,7 +11,7 @@ fn main() {
 
     const SOURCE: &str = "a b c d e f";
     // also supports labels with no messages to only emphasis on some areas
-    Report::build(ReportKind::Error, 2..3)
+    Report::build(ErrorKind, 2..3)
         .with_message("Incompatible types")
         .with_config(Config::default().with_compact(true))
         .with_label(Label::new(0..1).with_color(Color::Red))

--- a/examples/stresstest.rs
+++ b/examples/stresstest.rs
@@ -1,9 +1,9 @@
-use ariadne::{Color, ColorGenerator, Config, Label, Report, ReportKind, Source};
+use ariadne::{Color, ColorGenerator, Config, ErrorKind, Label, Report, Source};
 
 fn main() {
     let mut colors = ColorGenerator::new();
 
-    Report::build(ReportKind::Error, ("stresstest.tao", 13..13))
+    Report::build(ErrorKind, ("stresstest.tao", 13..13))
         .with_code(3)
         .with_message("Incompatible types".to_string())
         .with_label(


### PR DESCRIPTION
This PR suggests a refactor of `enum ReportKind<'a>` into `trait ReportKind` in order to get rid of the lifetime parameter. The default kinds `Error`, `Warning` and `Advice` are instead represented using empty structs that implement the trait. Custom report kinds can now instead be defined by implementing the `ReportKind` trait for new types (with or without lifetime parameters).

The motivation for this change is that the lifetime on `Report`, which stems specifically from `ReportKind::Custom`, only serves a purpose in the specific case where a custom report kind is used with a borrowed string, while being superfluous in other cases. If you're not using custom report kinds and want to be able to return reports from functions or store them in structs, you have to stick with `Report<'static>` everywhere, which feels unnecessary.

Bonus: a custom report kind should now only be colored if the `Config` has colors enabled. I assume this was a bug.

Note that this PR contains breaking changes to the public API, specifically the change of `ReportKind` from enum to trait, and the introduction of default trait implementations replacing the enum variants. If this is a concern, it might be possible to keep the old enum and make function signatures backwards compatible using generics, but I haven't looked into it.