### PR TITLE
chore: pub some fields about label

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -195,6 +195,16 @@ impl<S: Span> Label<S> {
         self.display_info.priority = priority;
         self
     }
+
+    /// getter for span
+    pub fn span(&self) -> &S {
+        &self.span
+    }
+
+    /// getter for display_info
+    pub fn display_info(&self) -> &LabelDisplay {
+        &self.display_info
+    }
 }
 
 /// A type representing a diagnostic that is ready to be written to output.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -120,11 +120,18 @@ impl<Id: fmt::Debug + Hash + PartialEq + Eq + ToOwned> Span for (Id, RangeInclus
 
 /// A type that represents the way a label should be displayed.
 #[derive(Clone, Debug, Hash, PartialEq, Eq)]
-struct LabelDisplay {
+pub struct LabelDisplay {
     msg: Option<String>,
     color: Option<Color>,
     order: i32,
     priority: i32,
+}
+
+impl LabelDisplay {
+    /// getter for msg
+    pub fn msg(&self) -> Option<&str> {
+        self.msg.as_deref()
+    }
 }
 
 /// A type that represents a labelled section of source code.


### PR DESCRIPTION
I meet an issue same as https://github.com/rolldown/ariadne/blob/c9f858f18d30983f48ef8c726d36ec439b6000eb/src/write.rs?plain=1#L1110, As a workaround, when normalizing `ariadne` Diagnostic I look up before and after span of label, convert them into normal `Error` String if the line is too long. 

Feel free to close this pr, if you are not satisfied.