### PR TITLE
feat: make `ColorGenerator` `const` friendly

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -8,7 +8,7 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
-  RUST_VERSION: 1.77.1
+  RUST_VERSION: 1.85.0
 
 jobs:
   build:


### PR DESCRIPTION
This allows precomputing a set of colors ahead of time (for people that are into that). To avoid generating the same colors for each instance, users can leverage the `const_random` crate to properly seed their generator.

I don't actually know how useful this is. I just saw a "constexpr all the things" opportunity and wanted to see if there was anything obvious preventing this.

One usecase I could think about is users wanting to generate a couple colors ahead of time, give each one semantic meaning and then use their meaning consistently. Something like this:

```rust
struct ColorPalette {
    types: Color,
    identifiers: Color,
    other: Color,
}
const COLORS: ColorPalette = {
    let mut gen = ColorGenerator::new();
    ColorPalette {
        types: gen.next(),
        identifiers: gen.next(),
        others: gen.next(),
    }
}
```
