### PR TITLE
Add Default trait to CharSet enum

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -428,9 +428,10 @@ pub enum LabelAttach {
 }
 
 /// Possible character sets to use when rendering diagnostics.
-#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Default)]
 pub enum CharSet {
     /// Unicode characters (an attempt is made to use only commonly-supported characters).
+    #[default]
     Unicode,
     /// ASCII-only characters.
     Ascii,


### PR DESCRIPTION
https://docs.rs/ariadne/latest/ariadne/struct.Config.html#method.with_char_set lists Unicode as the default it picks, and types should implement Default when they can just for user niceness, so here we go.