### PR TITLE
Unicode support

### DIFF
--- a/src/draw.rs
+++ b/src/draw.rs
@@ -41,6 +41,8 @@ impl Characters {
             vbar_gap: '┆',
             line_margin: '┤',
             uarrow: '▲',
+            // TODO: Revert when more commonly supported
+            // uarrow: '🭯',
             rarrow: '▶',
             ltop: '╭',
             mtop: '┬',
@@ -57,6 +59,8 @@ impl Characters {
             munderbar: '┬',
             underline: '─',
             underbar_single: '▲',
+            // TODO: Revert when more commonly supported
+            // underbar_single: '🭯',
         }
     }
 


### PR DESCRIPTION
As mentioned in #165, the current implementation of the Unicode variants of `uarrow` and `underbar_single` have issues displaying, both in common fixed-width fonts (I've tested Source Code Pro and Courier New), as well as on Github's browser view ([link](https://github.com/zesterer/ariadne/blob/a5c36da78430145e791e49d63e860816f9d367ef/src/draw.rs#L43), [link](https://github.com/zesterer/ariadne/blob/a5c36da78430145e791e49d63e860816f9d367ef/src/draw.rs#L59))

These characters appear to be currently implemented as `U+1FB6F`, a up-pointing triangular character. However, this character was implemented in March 2020 as part of Unicode 13.0, and therefore appears to have [limited support](https://www.fileformat.info/info/unicode/char/1FB6F/fontsupport.htm) among existing fonts (see the [Wikipedia page](https://en.wikipedia.org/wiki/Box-drawing_characters) for box drawing 🙂). Instead, the PR changes these characters to `U+25B2`, a long-existing character with [greater support](https://www.fileformat.info/info/unicode/char/25B2/fontsupport.htm) (as well as being from the same Unicode block, [Geometric Shapes](https://en.wikipedia.org/wiki/Geometric_Shapes_(Unicode_block)), as `rarrow`).

Note that this does introduce a slight gap between the arrow line and arrow head, which admittedly doesn't fit the aesthetic of the rest of the crate; in which case, it might be better to just use `mtop` in these cases? However, this is highly font-dependent, so might not make a different for some users - see below

```
Error: Incompatible types
   ╭─┤ <unknown>:2:10 │
   │
 2 ┤     () => 5,
   │           ▲  
   │           ╰── This is of type Nat
   │ 
 4 ┤     () => "5",
   │           ─┬─  
   │            ╰─── This is of type Str
───╯

```